### PR TITLE
Fix auto-execution bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,4 +29,5 @@ def main():
         print(f"{char}: {count}")
     print("============= END ===============")
 
-main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- prevent automatic execution of `main()` when module imported

## Testing
- `python3 -m py_compile main.py stats.py`


------
https://chatgpt.com/codex/tasks/task_e_6855ab1e38e48321abc5b4aa7e8b5b40